### PR TITLE
Enhance catalog and showtime services with movie details

### DIFF
--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/ImaxCatalogServiceApplication.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/ImaxCatalogServiceApplication.java
@@ -2,10 +2,12 @@ package com.cinema.imax_catalog_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableFeignClients
+@EnableDiscoveryClient
 public class ImaxCatalogServiceApplication {
 
 	public static void main(String[] args) {

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/client/TmdbClient.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/client/TmdbClient.java
@@ -2,6 +2,7 @@ package com.cinema.imax_catalog_service.client;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.Map;
@@ -9,12 +10,20 @@ import java.util.Map;
 @FeignClient(name = "tmdb-client", url = "${tmdb.base-url}")
 public interface TmdbClient {
 
+    /**
+     * Obtain movies on catalog.
+     */
     @GetMapping("/movie/now_playing")
-    Map<String, Object> getNowPlaying(
-            @RequestParam("api_key") String apiKey
+    Map<String, Object> getNowPlaying(@RequestParam("api_key") String apiKey);
+
+    /**
+     * Obtain complex details from a movie,
+     * Includes: runtime (duration), certification (rating), etc.
+     */
+    @GetMapping("/movie/{movieId}")
+    Map<String, Object> getMovieDetails(
+            @PathVariable("movieId") Integer movieId,
+            @RequestParam("api_key") String apiKey,
+            @RequestParam(value = "append_to_response", defaultValue = "release_dates") String appendToResponse
     );
-
 }
-
-
-

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/controller/CatalogController.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/controller/CatalogController.java
@@ -4,12 +4,16 @@ import com.cinema.imax_catalog_service.dto.response.MovieResponse;
 import com.cinema.imax_catalog_service.service.CatalogService;
 import com.cinema.imax_catalog_service.service.MovieSyncService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/api/movies")
 @RequiredArgsConstructor
 public class CatalogController {
 
@@ -17,20 +21,38 @@ public class CatalogController {
     private final MovieSyncService movieSyncService;
 
     /**
-     * Endpoint to obtain the actual catalog. (Movies from the db).
+     * Endpoint to sync the movies (useful for testing).
      */
-    @GetMapping("/movies/now-playing")
-    public List<MovieResponse> getNowPlaying() {
-        return catalogService.getNowPlayingMovies();
-    }
-
-    @GetMapping("/movies/sync-test")
+    @GetMapping("/sync-test")
     public String syncTest() {
         movieSyncService.syncNowPlayingMovies();
         return "Cartelera sincronizada!";
     }
 
+    /**
+     * Endpoint to obtain the actual catalog. (Movies from the db).
+     */
+    @GetMapping("/now-playing")
+    public List<MovieResponse> getNowPlaying() {
+        return catalogService.getNowPlayingMovies();
+    }
 
+    /**
+     * Endpoint to obtain a movie for id.
+     */
+    @GetMapping("/{id}")
+    public ResponseEntity<MovieResponse> getMovieById(@PathVariable Integer id) {
+        return catalogService.getMovieById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
 
+    /**
+     * Endpoint to show if a movie exist.
+     */
+    @GetMapping("/{id}/exists")
+    public ResponseEntity<Boolean> movieExists(@PathVariable Integer id) {
+        return ResponseEntity.ok(catalogService.isMovieInCatalog(id));
+    }
 
 }

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/dto/response/MovieResponse.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/dto/response/MovieResponse.java
@@ -17,8 +17,36 @@ public class MovieResponse {
 
     private Integer id;
     private String title;
+    private String originalTitle;
     private String overview;
     private String releaseDate;
+    private Integer duration;
+    private String rating;    // PG, PG-13, R, etc.
     private String posterPath;
     private List<Integer> genreIds;
+
+    /**
+     * Helper method to construct the URL.
+     */
+    public String getFullPosterUrl() {
+        if (posterPath != null && !posterPath.isEmpty()) {
+            return "https://image.tmdb.org/t/p/w500" + posterPath;
+        }
+        return null;
+    }
+
+    /**
+     * Helper to obtain the duration.
+     */
+    public String getFormattedDuration() {
+        if (duration == null) return "N/A";
+        int hours = duration / 60;
+        int minutes = duration % 60;
+        return hours + "h " + minutes + "m";
+    }
+
+    public boolean isFamilyFriendly() {
+        if (rating == null) return false;
+        return rating.equals("G") || rating.equals("PG") || rating.equals("PG-13");
+    }
 }

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/mapper/MovieMapperService.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/mapper/MovieMapperService.java
@@ -1,38 +1,37 @@
 package com.cinema.imax_catalog_service.mapper;
 
-import com.cinema.imax_catalog_service.client.MapperMethods;
-import com.cinema.imax_catalog_service.model.Movie;
 import com.cinema.imax_catalog_service.dto.response.MovieResponse;
+import com.cinema.imax_catalog_service.model.Movie;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MovieMapperService implements MapperMethods<MovieResponse, Movie> {
+public class MovieMapperService {
 
-    @Override
-    public Movie convertToEntity(MovieResponse response) {
-        if (response == null) return null;
-
-        return Movie.builder()
-                .id(response.getId())
-                .title(response.getTitle())
-                .overview(response.getOverview())
-                .releaseDate(response.getReleaseDate())
-                .posterPath(response.getPosterPath())
-                .genreIds(response.getGenreIds())
+    public MovieResponse convertToDto(Movie movie) {
+        return MovieResponse.builder()
+                .id(movie.getId())
+                .title(movie.getTitle())
+                .originalTitle(movie.getOriginalTitle())
+                .overview(movie.getOverview())
+                .releaseDate(movie.getReleaseDate())
+                .duration(movie.getDuration())
+                .rating(movie.getRating())
+                .posterPath(movie.getPosterPath())
+                .genreIds(movie.getGenreIds())
                 .build();
     }
 
-    @Override
-    public MovieResponse convertToDto(Movie entity) {
-        if (entity == null) return null;
-
-        return MovieResponse.builder()
-                .id(entity.getId())
-                .title(entity.getTitle())
-                .overview(entity.getOverview())
-                .releaseDate(entity.getReleaseDate())
-                .posterPath(entity.getPosterPath())
-                .genreIds(entity.getGenreIds())
+    public Movie convertToEntity(MovieResponse dto) {
+        return Movie.builder()
+                .id(dto.getId())
+                .title(dto.getTitle())
+                .originalTitle(dto.getOriginalTitle())
+                .overview(dto.getOverview())
+                .releaseDate(dto.getReleaseDate())
+                .duration(dto.getDuration())
+                .rating(dto.getRating())
+                .posterPath(dto.getPosterPath())
+                .genreIds(dto.getGenreIds())
                 .build();
     }
 }

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/model/Movie.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/model/Movie.java
@@ -14,7 +14,6 @@ import java.util.List;
 @Builder
 public class Movie {
 
-
     @Id
     private Integer id;
 
@@ -33,6 +32,11 @@ public class Movie {
     @Column(name = "release_date", length = 255)
     private String releaseDate;
 
+    @Column(name = "duration")
+    private Integer duration;
+
+    @Column(name = "rating", length = 10) // PG, PG-13, R, etc.
+    private String rating;
 
     @ElementCollection
     private List<Integer> genreIds;

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/service/CatalogService.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/service/CatalogService.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,5 +25,12 @@ public class CatalogService {
                 .collect(Collectors.toList());
     }
 
-    //TODO: get movie by id method..
+    public Optional<MovieResponse> getMovieById(Integer id) {
+        return movieRepository.findById(id)
+                .map(movieMapper::convertToDto);
+    }
+
+    public boolean isMovieInCatalog(Integer id) {
+        return movieRepository.existsById(id);
+    }
 }

--- a/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/service/MovieSyncService.java
+++ b/imax-catalog-service/src/main/java/com/cinema/imax_catalog_service/service/MovieSyncService.java
@@ -3,22 +3,22 @@ package com.cinema.imax_catalog_service.service;
 import com.cinema.imax_catalog_service.model.Movie;
 import com.cinema.imax_catalog_service.repository.MovieRepository;
 import com.cinema.imax_catalog_service.client.TmdbClient;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-//this class refresh the catalog automatically.
 @Service
+@Slf4j
 public class MovieSyncService {
 
     private final TmdbClient tmdbClient;
     private final MovieRepository movieRepository;
-    private static final Logger logger = Logger.getLogger(MovieSyncService.class.getName());
 
     @Value("${tmdb.api-key}")
     private String apiKey;
@@ -28,44 +28,140 @@ public class MovieSyncService {
         this.movieRepository = movieRepository;
     }
 
-    // Scheduler: se ejecuta todos los días a las 3am
+    /**
+     * Sync every day at 3am
+     */
     @Scheduled(cron = "0 0 3 * * ?")
     public void syncNowPlayingMovies() {
-        logger.info("Sincronizando películas...");
+        log.info(" Sync started...");
 
-        Map<String, Object> response = tmdbClient.getNowPlaying(apiKey); // <-- aquí
-        List<Map<String, Object>> results = (List<Map<String, Object>>) response.get("results");
+        try {
+            // 1. Obtain movies from catalog.
+            Map<String, Object> response = tmdbClient.getNowPlaying(apiKey);
+            List<Map<String, Object>> results = (List<Map<String, Object>>) response.get("results");
 
-        if (results == null || results.isEmpty()) {
-            logger.warning("No se obtuvieron películas de TMDB.");
-            return;
+            if (results == null || results.isEmpty()) {
+                log.warn("⚠ No se obtuvieron películas de TMDB");
+                return;
+            }
+
+            // 2. Process every movie to obtain complex details.
+            List<Movie> movies = new ArrayList<>();
+            int successCount = 0;
+            int failCount = 0;
+
+            for (Map<String, Object> movieMap : results) {
+                try {
+                    Movie movie = mapToEntityWithDetails(movieMap);
+                    movies.add(movie);
+                    successCount++;
+                } catch (Exception e) {
+                    failCount++;
+                    log.error("Error loading movie with ID: {}, error: {}",
+                            movieMap.get("id"), e.getMessage());
+                }
+            }
+
+            // 3. Refresh database.
+            if (!movies.isEmpty()) {
+                movieRepository.deleteAll();
+                movieRepository.saveAll(movies);
+                log.info("Completed sync: {} saved movies, {} errors",
+                        successCount, failCount);
+            } else {
+                log.warn("Couldn´t save movies in the db.");
+            }
+
+        } catch (Exception e) {
+            log.error("Critical error during sync: {}", e.getMessage(), e);
         }
-
-        List<Movie> movies = results.stream()
-                .map(this::mapToEntity)
-                .collect(Collectors.toList());
-
-        movieRepository.deleteAll();
-        movieRepository.saveAll(movies);
-
-        logger.info("Se sincronizaron " + movies.size() + " películas.");
     }
 
+    /**
+     *  Extract rating from EE-UU (PG, PG-13, R, etc.)
+     */
+    private String extractUsRating(Map<String, Object> details) {
+        try {
+            Map<String, Object> releaseDates = (Map<String, Object>) details.get("release_dates");
+            if (releaseDates == null) return null;
 
-    private Movie mapToEntity(Map<String, Object> movieMap) {
+            List<Map<String, Object>> results =
+                    (List<Map<String, Object>>) releaseDates.get("results");
+
+            if (results == null) return null;
+
+            // Search certification on EEUU (iso_3166_1 = "US")
+            for (Map<String, Object> country : results) {
+                if ("US".equals(country.get("iso_3166_1"))) {
+                    List<Map<String, Object>> releaseDatesList =
+                            (List<Map<String, Object>>) country.get("release_dates");
+
+                    if (releaseDatesList != null && !releaseDatesList.isEmpty()) {
+                        // Take the first certification available.
+                        String certification = (String) releaseDatesList.get(0).get("certification");
+                        if (certification != null && !certification.isEmpty()) {
+                            return certification;
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Couldn´t extract rating: {}", e.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Extract list of genre ID´s.
+     */
+    private List<Integer> extractGenreIds(Map<String, Object> movieMap) {
+        Object genreIds = movieMap.get("genre_ids");
+        if (genreIds instanceof List<?>) {
+            return ((List<?>) genreIds).stream()
+                    .filter(obj -> obj instanceof Number)
+                    .map(obj -> ((Number) obj).intValue())
+                    .collect(Collectors.toList());
+        }
+        return null;
+    }
+
+    /**
+     * Extract duration in minutes.
+     */
+    private Integer extractDuration(Map<String, Object> details) {
+        Object runtime = details.get("runtime");
+        if (runtime instanceof Number) {
+            return ((Number) runtime).intValue();
+        }
+        return null;
+    }
+
+    /**
+     * Map basic movie & obtains complex details (duration + rating)
+     */
+    private Movie mapToEntityWithDetails(Map<String, Object> movieMap) {
+        Integer movieId = movieMap.get("id") != null
+                ? ((Number) movieMap.get("id")).intValue()
+                : null;
+
+        if (movieId == null) {
+            throw new RuntimeException("Movie ID is null");
+        }
+
+        // Obtain complex details.
+        Map<String, Object> details = tmdbClient.getMovieDetails(movieId, apiKey, "release_dates");
+
+        // Construct entity with all the data.
         return Movie.builder()
-                .id(movieMap.get("id") != null ? ((Number) movieMap.get("id")).intValue() : null)
+                .id(movieId)
                 .title((String) movieMap.get("title"))
+                .originalTitle((String) details.get("original_title"))
                 .overview((String) movieMap.get("overview"))
                 .releaseDate((String) movieMap.get("release_date"))
                 .posterPath((String) movieMap.get("poster_path"))
-                .genreIds(movieMap.get("genre_ids") != null
-                        ? ((List<?>) movieMap.get("genre_ids")).stream()
-                        .map(n -> ((Number) n).intValue())
-                        .collect(Collectors.toList())
-                        : null)
+                .duration(extractDuration(details))
+                .rating(extractUsRating(details))
+                .genreIds(extractGenreIds(movieMap))
                 .build();
     }
-
-
 }

--- a/imax-showTime-service/pom.xml
+++ b/imax-showTime-service/pom.xml
@@ -1,74 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<!-- Herencia desde el POM padre -->
-	<parent>
-		<groupId>com.cinema</groupId>
-		<artifactId>imax-parent</artifactId>
-		<version>0.0.1-SNAPSHOT</version>
-		<relativePath>../pom.xml</relativePath>
-	</parent>
+    <!-- Herencia desde el POM padre -->
+    <parent>
+        <groupId>com.cinema</groupId>
+        <artifactId>imax-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-	<!-- Datos específicos del módulo -->
-	<artifactId>imax-showTime-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
-	<name>imax-showTime-service</name>
-	<description>Showtime module for Imax project. Communicates with Catalog service.</description>
+    <!-- Datos específicos del módulo -->
+    <artifactId>imax-showTime-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>imax-showTime-service</name>
+    <description>Showtime module for Imax project. Communicates with Catalog service.</description>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-actuator</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-data-jpa</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-config</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.cloud</groupId>
-			<artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-		</dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
+        </dependency>
 
-		<dependency>
-			<groupId>org.postgresql</groupId>
-			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>org.springframework.cloud</groupId>
-				<artifactId>spring-cloud-dependencies</artifactId>
-				<version>${spring-cloud.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/ImaxShowTimeServiceApplication.java
+++ b/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/ImaxShowTimeServiceApplication.java
@@ -3,9 +3,11 @@ package com.cinema.imax_showTime_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class ImaxShowTimeServiceApplication {
 
 	public static void main(String[] args) {

--- a/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/client/CatalogClient.java
+++ b/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/client/CatalogClient.java
@@ -1,0 +1,4 @@
+package com.cinema.imax_showTime_service.client;
+
+public interface CatalogClient {
+}


### PR DESCRIPTION
- Added duration, rating, and originalTitle fields to Movie and MovieResponse, and updated the sync logic to fetch detailed movie info from TMDB.
- CatalogController now provides endpoints to get a movie by ID and check existence.
- Refactored MovieMapperService for new fields.
- Enabled Feign clients and Eureka discovery in both services,
- added OpenFeign dependency to showtime service, and introduced a CatalogClient interface stub.