### PR TITLE
Integrate Feign client in reservation service and update endpoints / Leaving all set to provide MercadoApi payment process.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       POSTGRES_USER: ${DB_SHOWTIME_USER}
       POSTGRES_PASSWORD: ${DB_SHOWTIME_PASS}
     ports:
-      - "5433:5432" # Corregido: Mapea puerto local 5433 al puerto interno 5432
+      - "5433:5432"
     volumes:
       - showtime-data:/var/lib/postgresql/data
     healthcheck:
@@ -147,7 +147,7 @@ services:
       POSTGRES_USER: ${DB_RESERVATION_USER}
       POSTGRES_PASSWORD: ${DB_RESERVATION_PASS}
     ports:
-      - "5434:5432" # Corregido: Mapea puerto local 5434 al puerto interno 5432
+      - "5434:5432"
     volumes:
       - reservation-data:/var/lib/postgresql/data
     healthcheck:

--- a/imax-catalog-service/src/main/resources/application.yml
+++ b/imax-catalog-service/src/main/resources/application.yml
@@ -70,7 +70,7 @@ logging:
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
 
-# ==================== ACTUATOR (opcional pero recomendado) ====================
+# ==================== ACTUATOR ====================
 management:
   endpoints:
     web:

--- a/imax-eureka-config/src/main/java/com/cinema/imax_eureka_config/ImaxEurekaConfigApplication.java
+++ b/imax-eureka-config/src/main/java/com/cinema/imax_eureka_config/ImaxEurekaConfigApplication.java
@@ -13,4 +13,3 @@ public class ImaxEurekaConfigApplication {
 	}
 
 }
-

--- a/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/ImaxReservationServiceApplication.java
+++ b/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/ImaxReservationServiceApplication.java
@@ -2,8 +2,12 @@ package com.cinema.imax_reservation_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableDiscoveryClient
 public class ImaxReservationServiceApplication {
 
 	public static void main(String[] args) {

--- a/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/client/ShowTimeClient.java
+++ b/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/client/ShowTimeClient.java
@@ -2,10 +2,7 @@ package com.cinema.imax_reservation_service.client;
 
 import com.cinema.imax_reservation_service.dto.ShowTimeDTO;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @FeignClient(
         name = "imax-showtime-service",
@@ -16,6 +13,6 @@ public interface ShowTimeClient {
     @GetMapping("/{id}")
     ShowTimeDTO getShowTimeById(@PathVariable Long id);
 
-    @PatchMapping("/internal/{id}/reserve")
+    @PutMapping("/internal/{id}/reserve")
     ShowTimeDTO reserveSeats(@PathVariable Long id, @RequestParam Integer seats);
 }

--- a/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/controller/ReservationController.java
+++ b/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/controller/ReservationController.java
@@ -112,6 +112,34 @@ public class ReservationController {
     public ResponseEntity<List<Reservation>> getReservationsByShowTime(@PathVariable Long showTimeId) {
         return ResponseEntity.ok(reservationService.getReservationsByShowTime(showTimeId));
     }
+    // ===================== TEST FEIGN CLIENT CONNECTION =====================
+
+    @GetMapping("/showtimes/{id}")
+    public ResponseEntity<?> getShowTimeFromShowtimeService(@PathVariable Long id) {
+        try {
+            // Llamada directa al Feign Client
+            var showTime = reservationService.getShowTimeById(id);
+            return ResponseEntity.ok(showTime);
+        } catch (Exception e) {
+            log.error("Error fetching showtime {}", id, e);
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .body(Map.of("error", "Error contacting showtime-service", "message", e.getMessage()));
+        }
+    }
+
+    @PutMapping("/showtimes/{id}/reserve")
+    public ResponseEntity<?> reserveSeatsInShowtimeService(
+            @PathVariable Long id,
+            @RequestParam Integer seats) {
+        try {
+            var updated = reservationService.reserveSeatsInShowTime(id, seats);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            log.error("Error reserving seats in showtime-service", e);
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
+                    .body(Map.of("error", "Error contacting showtime-service", "message", e.getMessage()));
+        }
+    }
 
     /**
      * Confirmar pago (webhook o llamada manual)

--- a/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/service/ReservationService.java
+++ b/imax-reservation-service/src/main/java/com/cinema/imax_reservation_service/service/ReservationService.java
@@ -104,6 +104,14 @@ public class ReservationService {
         return reservationRepository.findByShowTimeId(showTimeId);
     }
 
+    public ShowTimeDTO getShowTimeById(Long id) {
+        return showTimeClient.getShowTimeById(id);
+    }
+
+    public ShowTimeDTO reserveSeatsInShowTime(Long id, Integer seats) {
+        return showTimeClient.reserveSeats(id, seats);
+    }
+
     @Transactional
     public Reservation confirmPayment(UUID reservationId, String paymentId) {
         log.info("Confirming payment for reservation: {}", reservationId);

--- a/imax-reservation-service/src/main/resources/application.yml
+++ b/imax-reservation-service/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   config:
     import: "optional:configserver:"
   datasource:
-    url: ${DB_RESERVATION_URL:jdbc:postgresql://localhost:5434/reservationdb}
+    url: ${DB_RESERVATION_URL:jdbc:postgresql://localhost:5434/reservation_db}
     username: ${DB_RESERVATION_USER:reservationuser}
     password: ${DB_RESERVATION_PASS:secretpassword}
     driver-class-name: org.postgresql.Driver

--- a/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/controller/ShowTimeController.java
+++ b/imax-showTime-service/src/main/java/com/cinema/imax_showTime_service/controller/ShowTimeController.java
@@ -120,7 +120,7 @@ public class ShowTimeController {
     /**
      * Reserve seats(FOR PRIVATE EVENTS ONLY(FOR THE MOMENT XD)).
      */
-    @PatchMapping("/internal/{id}/reserve")
+    @PutMapping("/internal/{id}/reserve")
     public ResponseEntity<ShowTime> reserveSeats(
             @PathVariable Long id,
             @RequestParam Integer seats) {

--- a/imax-showTime-service/src/main/resources/application.yml
+++ b/imax-showTime-service/src/main/resources/application.yml
@@ -16,7 +16,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
     properties:
       hibernate:
         format_sql: true
@@ -27,16 +26,15 @@ eureka:
     instance-id: ${spring.application.name}:${server.port}
     non-secure-port: 8082
 
-# ✅ Configuración básica de Feign (sin circuit breaker por ahora)
+# Basic feign config. (without circuit breaker, for now :) )
 feign:
   client:
     config:
       default:
         connectTimeout: 5000
         readTimeout: 5000
-        loggerLevel: basic  # Cambia a 'full' si quieres ver más detalles en los logs
+        loggerLevel: basic  #'full' if you want to see more details.
 
-# ✅ Logging para debug (opcional, puedes comentar después)
 logging:
   level:
     com.cinema.imax_showTime_service: DEBUG


### PR DESCRIPTION
- Enabled Feign client and service discovery in the reservation service.
- Added endpoints in ReservationController to test Feign client connectivity with the showtime service.
- Changed seat reservation endpoint from PATCH to PUT in both reservation and showtime services for consistency. - Updated database URL in reservation service config and made minor cleanup and comment improvements across configuration files.